### PR TITLE
fix broken react-calendar navigation

### DIFF
--- a/src/components/DiaryCalendar.tsx
+++ b/src/components/DiaryCalendar.tsx
@@ -71,6 +71,8 @@ const DiaryCalendar = () => {
   };
 
   const onDayClick = (value: Value) => {
+    // convert datestring from '2021-02-03T05:00:00.000Z' to '2020-02-03', which is what
+    // the dateToIds map uses for keys
     const dateClicked = value instanceof Date ? value.toISOString().split('T')[0] : null;
     if (dateClicked && datesToIds[dateClicked]) {
       router.push(`/comic/${datesToIds[dateClicked]}`);
@@ -89,18 +91,15 @@ const DiaryCalendar = () => {
     <OuterContainer>
       <InnerContainer>
         <StyledCalendar
-          activeStartDate={new Date(2019, 0, 1)}
+          defaultActiveStartDate={new Date(2019, 0, 1)}
           locale="en-US"
-          maxDate={new Date()}
+          maxDate={new Date(2021, 10, 27)}
           minDate={new Date(2019, 0, 1)}
-          // TODO: tileClassName={tileClassName}
-          // TODO: tileContent={tileContent}
           calendarType="gregory"
           onChange={onDateChange}
           onClickDay={onDayClick}
           tileDisabled={tileDisabled}
           value={selectedDate}
-          // showWeekNumbers
         />
       </InnerContainer>
     </OuterContainer>


### PR DESCRIPTION
Prior to this commit, it was not possible to use the '<', '<<', '>' and '>>' buttons on the StyledCalendar component to navigate the months and years of the calendar on comic/ page's Ego Gala section.

I'm not sure why switching activeStartDate -> defaultActiveStartDate worked, because the documentation doesn't clearly explain what the difference is between a `controlled` calendar and an `uncontrolled` calendar... but this works and doesn't seem to break so we're going with it.