### PR TITLE
fix comic submit form by adding missing thumbnail_url argument

### DIFF
--- a/src/pages/api/cms/submitComic.ts
+++ b/src/pages/api/cms/submitComic.ts
@@ -20,6 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       category,
       description,
       publication_date,
+      thumbnail_url: panels[0].image_url, // default to using the comic's first panel image URL as the thumbnail
     });
     await comic.save();
 


### PR DESCRIPTION
This field is required on the Comic document, so we need to add it